### PR TITLE
Add ports to redpanda-2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,6 +65,8 @@ services:
   #   ports:
   #     - 8083:8083
   #     - 9093:9093
+  #     - 28083:28083
+  #     - 29093:29093
 
   redpanda-console:
     image: docker.redpanda.com/redpandadata/console:latest


### PR DESCRIPTION
Based on the `redpanda-1` definition, it looks like 2 ports are missing from the `ports` section.

The `redpanda-2` broker didn't show up in my Redpanda console until I added those ports.

https://redpandacommunity.slack.com/archives/C03JCF2UFGD/p1714394602058029